### PR TITLE
update to recent rust version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,95 +2,165 @@
 name = "theca"
 version = "1.0.0-nightly"
 dependencies = [
- "docopt 0.6.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex_macros 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust-crypto 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "docopt 0.6.81 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "docopt"
-version = "0.6.55"
+version = "0.6.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gcc"
-version = "0.3.3"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "libc"
-version = "0.1.3"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "log"
-version = "0.3.0"
+name = "memchr"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand"
-version = "0.3.3"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "regex_macros"
-version = "0.1.14"
+version = "0.1.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "regex 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "regex-syntax"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rust-crypto"
-version = "0.2.26"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.7"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "strsim"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "tempdir"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "term"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread-id"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.21"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "utf8-ranges"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,10 @@ doc = false
 [dependencies]
 time = "*"
 regex = "*"
-regex_macros = "*"
 rustc-serialize = "*"
 docopt = "*"
 rust-crypto = "*"
 rand = "*"
 tempdir = "*"
+libc = "*"
+term = "*"

--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ the bug, and if you're really awesome a test case that exposes it.
 ### TODO
 
 * clean-ups/optimizations pretty much everywhere
-* `ThecaProfile` and `ThecaItem` and assosiated functions should be moved out of `src/theca/lib.rs`
+* `Profile` and `Item` and assosiated functions should be moved out of `src/theca/lib.rs`
   to their own file
 * `list-profiles` should be alphabetic
 * `bash_complete.sh` could use a lot of improvement, `_theca` also, but less...

--- a/src/bin/theca.rs
+++ b/src/bin/theca.rs
@@ -14,8 +14,8 @@ extern crate theca;
 extern crate docopt;
 
 use docopt::Docopt;
-use theca::{Args, ThecaProfile, setup_args, parse_cmds, version};
-use theca::errors::ThecaError;
+use theca::{Args, Profile, setup_args, parse_cmds, version};
+use theca::errors::Error;
 use std::process::exit;
 
 static USAGE: &'static str = "
@@ -90,14 +90,14 @@ Miscellaneous:
     -v, --version                       Display the version of theca and exit.
 ";
 
-fn theca_main() -> Result<(), ThecaError> {
+fn theca_main() -> Result<(), Error> {
     let mut args: Args = try!(Docopt::new(USAGE)
                                   .unwrap()
                                   .version(Some(version()))
                                   .decode());
     try!(setup_args(&mut args));
 
-    let (mut profile, profile_fingerprint) = try!(ThecaProfile::new(&args.flag_profile,
+    let (mut profile, profile_fingerprint) = try!(Profile::new(&args.flag_profile,
                                                                     &args.flag_profile_folder,
                                                                     &args.flag_key,
                                                                     args.cmd_new_profile,

--- a/src/bin/theca.rs
+++ b/src/bin/theca.rs
@@ -1,5 +1,5 @@
-//  _   _                    
-// | |_| |__   ___  ___ __ _ 
+//  _   _
+// | |_| |__   ___  ___ __ _
 // | __| '_ \ / _ \/ __/ _` |
 // | |_| | | |  __/ (_| (_| |
 //  \__|_| |_|\___|\___\__,_|
@@ -10,15 +10,13 @@
 //   the theca binary, we finish error unwinding in here and set
 //   the exit status if there was an error.
 
-#![feature(exit_status)]
-
 extern crate theca;
 extern crate docopt;
 
 use docopt::Docopt;
 use theca::{Args, ThecaProfile, setup_args, parse_cmds, version};
-use theca::errors::{ThecaError};
-use std::env::{set_exit_status};
+use theca::errors::ThecaError;
+use std::process::exit;
 
 static USAGE: &'static str = "
 theca - simple cli note taking tool
@@ -93,19 +91,18 @@ Miscellaneous:
 ";
 
 fn theca_main() -> Result<(), ThecaError> {
-    let mut args: Args = try!(Docopt::new(USAGE).unwrap()
-                                                .version(Some(version()))
-                                                .decode());
+    let mut args: Args = try!(Docopt::new(USAGE)
+                                  .unwrap()
+                                  .version(Some(version()))
+                                  .decode());
     try!(setup_args(&mut args));
 
-    let (mut profile, profile_fingerprint) = try!(ThecaProfile::new(
-        &args.flag_profile,
-        &args.flag_profile_folder,
-        &args.flag_key,
-        args.cmd_new_profile,
-        args.flag_encrypted,
-        args.flag_yes
-    ));
+    let (mut profile, profile_fingerprint) = try!(ThecaProfile::new(&args.flag_profile,
+                                                                    &args.flag_profile_folder,
+                                                                    &args.flag_key,
+                                                                    args.cmd_new_profile,
+                                                                    args.flag_encrypted,
+                                                                    args.flag_yes));
 
     try!(parse_cmds(&mut profile, &mut args, &profile_fingerprint));
 
@@ -117,8 +114,8 @@ fn main() {
     match theca_main() {
         Err(e) => {
             println!("{}", e.desc);
-            set_exit_status(1);
-        },
-        Ok(_) => ()
+            exit(1);
+        }
+        Ok(_) => (),
     };
 }

--- a/src/theca/crypt.rs
+++ b/src/theca/crypt.rs
@@ -1,5 +1,5 @@
-//  _   _                    
-// | |_| |__   ___  ___ __ _ 
+//  _   _
+// | |_| |__   ___  ___ __ _
 // | __| '_ \ / _ \/ __/ _` |
 // | |_| | | |  __/ (_| (_| |
 //  \__|_| |_|\___|\___\__,_|
@@ -10,47 +10,37 @@
 //   defintions of the AES encryption, decryption, and PBKDF2 key derivation
 //   functions required to read and write encrypted profiles.
 
-use std::iter::{repeat};
+use std::iter::repeat;
 use crypto::{symmetriccipher, buffer, aes, blockmodes};
 use crypto::buffer::{ReadBuffer, WriteBuffer, BufferResult};
-use crypto::pbkdf2::{pbkdf2};
-use crypto::hmac::{Hmac};
-use crypto::sha2::{Sha256};
-use crypto::digest::{Digest};
-use crypto::fortuna::{Fortuna};
+use crypto::pbkdf2::pbkdf2;
+use crypto::hmac::Hmac;
+use crypto::sha2::Sha256;
+use crypto::digest::Digest;
+use crypto::fortuna::Fortuna;
 use rand::{SeedableRng, Rng};
 
 // ALL the encryption functions thx rust-crypto ^_^
-pub fn encrypt(
-    data: &[u8],
-    key: &[u8]
-) -> Result<Vec<u8>, symmetriccipher::SymmetricCipherError> {
+pub fn encrypt(data: &[u8], key: &[u8]) -> Result<Vec<u8>, symmetriccipher::SymmetricCipherError> {
     let mut iv = [0u8; 16];
     let mut f: Fortuna = SeedableRng::from_seed(data);
     f.fill_bytes(&mut iv);
 
-    let mut encryptor = aes::cbc_encryptor(
-            aes::KeySize::KeySize256,
-            key,
-            &iv,
-            blockmodes::PkcsPadding);
+    let mut encryptor = aes::cbc_encryptor(aes::KeySize::KeySize256,
+                                           key,
+                                           &iv,
+                                           blockmodes::PkcsPadding);
 
     let mut final_result = Vec::<u8>::new();
-    final_result.push_all(&iv);
+    final_result.extend(&iv);
     let mut read_buffer = buffer::RefReadBuffer::new(data);
     let mut buffer = [0; 4096];
     let mut write_buffer = buffer::RefWriteBuffer::new(&mut buffer);
 
     loop {
-        let result = try!(encryptor.encrypt(
-            &mut read_buffer,
-            &mut write_buffer,
-            true
-        ));
+        let result = try!(encryptor.encrypt(&mut read_buffer, &mut write_buffer, true));
 
-        final_result.push_all(
-            write_buffer.take_read_buffer().take_remaining()
-        );
+        final_result.extend(write_buffer.take_read_buffer().take_remaining());
 
         match result {
             BufferResult::BufferUnderflow => break,
@@ -61,17 +51,15 @@ pub fn encrypt(
     Ok(final_result)
 }
 
-pub fn decrypt(
-    encrypted_data: &[u8],
-    key: &[u8]
-) -> Result<Vec<u8>, symmetriccipher::SymmetricCipherError> {
+pub fn decrypt(encrypted_data: &[u8],
+               key: &[u8])
+               -> Result<Vec<u8>, symmetriccipher::SymmetricCipherError> {
     let iv = &encrypted_data[0..16];
 
-    let mut decryptor = aes::cbc_decryptor(
-            aes::KeySize::KeySize256,
-            key,
-            iv,
-            blockmodes::PkcsPadding);
+    let mut decryptor = aes::cbc_decryptor(aes::KeySize::KeySize256,
+                                           key,
+                                           iv,
+                                           blockmodes::PkcsPadding);
 
     let mut final_result = Vec::<u8>::new();
     let mut read_buffer = buffer::RefReadBuffer::new(&encrypted_data[16..]);
@@ -79,14 +67,8 @@ pub fn decrypt(
     let mut write_buffer = buffer::RefWriteBuffer::new(&mut buffer);
 
     loop {
-        let result = try!(decryptor.decrypt(
-            &mut read_buffer,
-            &mut write_buffer,
-            true
-        ));
-        final_result.push_all(
-            write_buffer.take_read_buffer().take_remaining()
-        );
+        let result = try!(decryptor.decrypt(&mut read_buffer, &mut write_buffer, true));
+        final_result.extend(write_buffer.take_read_buffer().take_remaining());
         match result {
             BufferResult::BufferUnderflow => break,
             BufferResult::BufferOverflow => {}

--- a/src/theca/errors.rs
+++ b/src/theca/errors.rs
@@ -7,12 +7,12 @@
 // licensed under the MIT license <http://opensource.org/licenses/MIT>
 //
 // errors.rs
-//   definitions for ThecaError, a catch-all for converting various
+//   definitions for Error, a catch-all for converting various
 //   lib errors.
 
 use std::fmt;
 use std::convert::From;
-use std::error::Error;
+use std::error::Error as StdError;
 use std::io::Error as IoError;
 use std::string::FromUtf8Error;
 use std::time::SystemTimeError;
@@ -23,6 +23,7 @@ use docopt;
 use term;
 
 pub use self::ErrorKind::{TermError, InternalIoError, GenericError};
+pub type Result<T> = ::std::result::Result<T, Error>;
 
 #[derive(Debug)]
 pub enum ErrorKind {
@@ -32,24 +33,24 @@ pub enum ErrorKind {
 }
 
 #[derive(Debug)]
-pub struct ThecaError {
+pub struct Error {
     pub kind: ErrorKind,
     pub desc: String,
     pub detail: Option<String>,
 }
 
-impl fmt::Display for ThecaError {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", &self.desc)
     }
 }
 
-impl Error for ThecaError {
+impl StdError for Error {
     fn description(&self) -> &str {
         &self.desc
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&StdError> {
         match self.kind {
             ErrorKind::TermError(ref e) => Some(e),
             ErrorKind::InternalIoError(ref e) => Some(e),
@@ -61,7 +62,7 @@ impl Error for ThecaError {
 macro_rules! specific_fail {
     ($short:expr) => {
         return Err(::std::convert::From::from(
-            ThecaError {
+            Error {
                 kind: GenericError,
                 desc: $short,
                 detail: None
@@ -90,9 +91,9 @@ macro_rules! try_errno {
     }
 }
 
-impl From<EncoderError> for ThecaError {
-    fn from(err: EncoderError) -> ThecaError {
-        ThecaError {
+impl From<EncoderError> for Error {
+    fn from(err: EncoderError) -> Error {
+        Error {
             kind: GenericError,
             desc: err.description().to_string(),
             detail: None,
@@ -100,9 +101,9 @@ impl From<EncoderError> for ThecaError {
     }
 }
 
-impl From<IoError> for ThecaError {
-    fn from(err: IoError) -> ThecaError {
-        ThecaError {
+impl From<IoError> for Error {
+    fn from(err: IoError) -> Error {
+        Error {
             kind: GenericError,
             desc: err.description().into(),
             detail: None,
@@ -110,9 +111,9 @@ impl From<IoError> for ThecaError {
     }
 }
 
-impl From<term::Error> for ThecaError {
-    fn from(err: term::Error) -> ThecaError {
-        ThecaError {
+impl From<term::Error> for Error {
+    fn from(err: term::Error) -> Error {
+        Error {
             desc: err.description().into(),
             kind: TermError(err),
             detail: None,
@@ -120,9 +121,9 @@ impl From<term::Error> for ThecaError {
     }
 }
 
-impl From<(ErrorKind, &'static str)> for ThecaError {
-    fn from((kind, desc): (ErrorKind, &'static str)) -> ThecaError {
-        ThecaError {
+impl From<(ErrorKind, &'static str)> for Error {
+    fn from((kind, desc): (ErrorKind, &'static str)) -> Error {
+        Error {
             kind: kind,
             desc: desc.to_string(),
             detail: None,
@@ -130,9 +131,9 @@ impl From<(ErrorKind, &'static str)> for ThecaError {
     }
 }
 
-impl From<SystemTimeError> for ThecaError {
-    fn from(err: SystemTimeError) -> ThecaError {
-        ThecaError {
+impl From<SystemTimeError> for Error {
+    fn from(err: SystemTimeError) -> Error {
+        Error {
             kind: GenericError,
             desc: err.description().into(),
             detail: None,
@@ -140,9 +141,9 @@ impl From<SystemTimeError> for ThecaError {
     }
 }
 
-impl From<ParseError> for ThecaError {
-    fn from(err: ParseError) -> ThecaError {
-        ThecaError {
+impl From<ParseError> for Error {
+    fn from(err: ParseError) -> Error {
+        Error {
             kind: GenericError,
             desc: format!("time parsing error: {}", err),
             detail: None,
@@ -150,9 +151,9 @@ impl From<ParseError> for ThecaError {
     }
 }
 
-impl From<FromUtf8Error> for ThecaError {
-    fn from(err: FromUtf8Error) -> ThecaError {
-        ThecaError {
+impl From<FromUtf8Error> for Error {
+    fn from(err: FromUtf8Error) -> Error {
+        Error {
             kind: GenericError,
             desc: format!("is this profile encrypted? ({})", err),
             detail: None,
@@ -160,9 +161,9 @@ impl From<FromUtf8Error> for ThecaError {
     }
 }
 
-impl From<SymmetricCipherError> for ThecaError {
-    fn from(_: SymmetricCipherError) -> ThecaError {
-        ThecaError {
+impl From<SymmetricCipherError> for Error {
+    fn from(_: SymmetricCipherError) -> Error {
+        Error {
             kind: GenericError,
             desc: "invalid encryption key".to_string(),
             detail: None,
@@ -170,9 +171,9 @@ impl From<SymmetricCipherError> for ThecaError {
     }
 }
 
-impl From<docopt::Error> for ThecaError {
-    fn from(err: docopt::Error) -> ThecaError {
-        ThecaError {
+impl From<docopt::Error> for Error {
+    fn from(err: docopt::Error) -> Error {
+        Error {
             kind: GenericError,
             desc: err.to_string(),
             detail: None,
@@ -180,9 +181,9 @@ impl From<docopt::Error> for ThecaError {
     }
 }
 
-impl From<fmt::Error> for ThecaError {
-    fn from(_: fmt::Error) -> ThecaError {
-        ThecaError {
+impl From<fmt::Error> for Error {
+    fn from(_: fmt::Error) -> Error {
+        Error {
             kind: GenericError,
             desc: "formatting error".to_string(),
             detail: None,

--- a/src/theca/errors.rs
+++ b/src/theca/errors.rs
@@ -24,16 +24,38 @@ use term;
 
 pub use self::ErrorKind::{TermError, InternalIoError, GenericError};
 
+#[derive(Debug)]
 pub enum ErrorKind {
     TermError(term::Error),
     InternalIoError(IoError),
     GenericError,
 }
 
+#[derive(Debug)]
 pub struct ThecaError {
     pub kind: ErrorKind,
     pub desc: String,
     pub detail: Option<String>,
+}
+
+impl fmt::Display for ThecaError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", &self.desc)
+    }
+}
+
+impl Error for ThecaError {
+    fn description(&self) -> &str {
+        &self.desc
+    }
+
+    fn cause(&self) -> Option<&Error> {
+        match self.kind {
+            ErrorKind::TermError(ref e) => Some(e),
+            ErrorKind::InternalIoError(ref e) => Some(e),
+            _ => None,
+        }
+    }
 }
 
 macro_rules! specific_fail {

--- a/src/theca/lib.rs
+++ b/src/theca/lib.rs
@@ -922,11 +922,7 @@ pub fn parse_cmds(profile: &mut ThecaProfile,
         // view
         if !args.arg_id.is_empty() {
             try!(profile.view_note(args.arg_id[0], args.flag_json, args.flag_condensed));
-            return Ok(());
-        }
-
-        // search
-        if args.cmd_search {
+        } else if args.cmd_search {
             try!(profile.search_notes(&args.arg_pattern,
                                       args.flag_regex,
                                       args.flag_limit,
@@ -938,16 +934,9 @@ pub fn parse_cmds(profile: &mut ThecaProfile,
                                       args.flag_none,
                                       args.flag_started,
                                       args.flag_urgent));
-            return Ok(());
-        }
-
-        // stats
-        if args.cmd_info {
+        } else if args.cmd_info {
             try!(profile.stats(&args.flag_profile));
-            return Ok(());
-        }
-
-        if args.cmd_import {
+        } else if args.cmd_import {
             // reverse(?) transfer a note
             let mut from_args = args.clone();
             from_args.cmd_transfer = args.cmd_import;
@@ -965,17 +954,10 @@ pub fn parse_cmds(profile: &mut ThecaProfile,
                 ));
 
             try!(parse_cmds(&mut from_profile, &mut from_args, &from_fingerprint));
-            return Ok(());
-        }
-
-        if args.cmd_list_profiles {
+        } else if args.cmd_list_profiles {
             let profile_path = try!(find_profile_folder(&args.flag_profile_folder));
             try!(profiles_in_folder(&profile_path));
-            return Ok(());
-        }
-
-        // list
-        if args.arg_id.is_empty() {
+        } else if args.arg_id.is_empty() {
             try!(profile.list_notes(args.flag_limit,
                                     args.flag_condensed,
                                     args.flag_json,
@@ -985,7 +967,6 @@ pub fn parse_cmds(profile: &mut ThecaProfile,
                                     args.flag_none,
                                     args.flag_started,
                                     args.flag_urgent));
-            return Ok(());
         }
     }
 

--- a/src/theca/lib.rs
+++ b/src/theca/lib.rs
@@ -23,7 +23,7 @@ extern crate rand;
 extern crate tempdir;
 
 // std lib imports
-use std::env::var;
+use std::env;
 use std::io::{self, stdin, Read, Write};
 use std::iter::repeat;
 use std::fs::{File, create_dir};
@@ -787,9 +787,10 @@ impl ThecaProfile {
                               started_status,
                               urgent_status));
         } else {
-            match json {
-                true => println!("[]"),
-                false => println!("nothing found"),
+            if json {
+                println!("[]");
+            } else {
+                println!("nothing found");
             }
         }
         Ok(())
@@ -797,23 +798,17 @@ impl ThecaProfile {
 }
 
 pub fn setup_args(args: &mut Args) -> Result<(), ThecaError> {
-    match var("THECA_DEFAULT_PROFILE") {
-        Ok(val) => {
-            if args.flag_profile.is_empty() && !val.is_empty() {
-                args.flag_profile = val;
-            }
+    if let Ok(val) = env::var("THECA_DEFAULT_PROFILE") {
+        if args.flag_profile.is_empty() && !val.is_empty() {
+            args.flag_profile = val;
         }
-        Err(_) => (),
-    };
+    }
 
-    match var("THECA_PROFILE_FOLDER") {
-        Ok(val) => {
-            if args.flag_profile_folder.is_empty() && !val.is_empty() {
-                args.flag_profile_folder = val;
-            }
+    if let Ok(val) = env::var("THECA_PROFILE_FOLDER") {
+        if args.flag_profile_folder.is_empty() && !val.is_empty() {
+            args.flag_profile_folder = val;
         }
-        Err(_) => (),
-    };
+    }
 
     // if key is provided but --encrypted not set, it prob should be
     if !args.flag_key.is_empty() && !args.flag_encrypted {

--- a/src/theca/lib.rs
+++ b/src/theca/lib.rs
@@ -832,127 +832,132 @@ pub fn parse_cmds(profile: &mut ThecaProfile,
                   args: &mut Args,
                   profile_fingerprint: &u64)
                   -> Result<(), ThecaError> {
-    if [args.cmd_add,
-        args.cmd_edit,
-        args.cmd_encrypt_profile,
-        args.cmd_del,
-        args.cmd_decrypt_profile,
-        args.cmd_transfer,
-        args.cmd_clear,
-        args.cmd_new_profile]
-           .iter()
-           .any(|c| *c) {
-        // add
-        if args.cmd_add {
-            try!(profile.add_note(&args.arg_title,
-                                  &args.flag_body,
-                                  args.flag_started,
-                                  args.flag_urgent,
-                                  args.cmd__,
-                                  args.flag_editor,
-                                  true));
-        }
-
-        // edit
-        if args.cmd_edit {
-            try!(profile.edit_note(args.arg_id[0],
-                                   &args.arg_title,
-                                   &args.flag_body,
-                                   args.flag_started,
-                                   args.flag_urgent,
-                                   args.flag_none,
-                                   args.cmd__,
-                                   args.flag_editor,
-                                   args.flag_encrypted,
-                                   args.flag_yes));
-        }
-
-        // delete
-        if args.cmd_del {
-            profile.delete_note(&args.arg_id);
-        }
-
-        // transfer
-        if args.cmd_transfer {
-            // transfer a note
-            try!(profile.transfer_note(args));
-        }
-
-        // clear
-        if args.cmd_clear {
-            try!(profile.clear(args.flag_yes));
-        }
-
-        // decrypt profile
-        // FIXME: should test how this interacts with save_to_file when the profile has
-        //        changed during execution
-        if args.cmd_decrypt_profile {
-            profile.encrypted = false; // is it that easy? i think it is
-            println!("decrypting '{}'", args.flag_profile);
-        }
-
-        // encrypt profile
-        // FIXME: should test how this interacts with save_to_file when the profile has
-        //        changed during execution
-        if args.cmd_encrypt_profile {
-            // get the new key
-            if args.flag_new_key.is_empty() {
-                args.flag_new_key = try!(get_password());
-            }
-
-            // set args.key and args.encrypted
-            args.flag_encrypted = true;
-            args.flag_key = args.flag_new_key.clone();
-
-            // set profile to encrypted
-            profile.encrypted = true;
-            println!("encrypting '{}'", args.flag_profile);
-        }
-
-        // new profile
-        if args.cmd_new_profile {
-            if args.cmd_new_profile && args.arg_name.is_empty() {
-                args.arg_name.push("default".to_string())
-            }
-            println!("creating profile '{}'", args.arg_name[0]);
-        }
-
-        try!(profile.save_to_file(args, profile_fingerprint));
-    } else {
-        // view
-        if !args.arg_id.is_empty() {
-            try!(profile.view_note(args.arg_id[0], args.flag_json, args.flag_condensed));
-        }
-
-        // search
-        if args.cmd_search {
-            try!(profile.search_notes(&args.arg_pattern,
-                                      args.flag_regex,
-                                      args.flag_limit,
-                                      args.flag_condensed,
-                                      args.flag_json,
-                                      args.flag_datesort,
-                                      args.flag_reverse,
-                                      args.flag_search_body,
-                                      args.flag_none,
+    match [args.cmd_add,
+           args.cmd_edit,
+           args.cmd_encrypt_profile,
+           args.cmd_del,
+           args.cmd_decrypt_profile,
+           args.cmd_transfer,
+           args.cmd_clear,
+           args.cmd_new_profile]
+              .iter()
+              .any(|c| c == &true) {
+        true => {
+            // add
+            if args.cmd_add {
+                try!(profile.add_note(&args.arg_title,
+                                      &args.flag_body,
                                       args.flag_started,
-                                      args.flag_urgent));
+                                      args.flag_urgent,
+                                      args.cmd__,
+                                      args.flag_editor,
+                                      true));
+            }
+
+            // edit
+            if args.cmd_edit {
+                try!(profile.edit_note(args.arg_id[0],
+                                       &args.arg_title,
+                                       &args.flag_body,
+                                       args.flag_started,
+                                       args.flag_urgent,
+                                       args.flag_none,
+                                       args.cmd__,
+                                       args.flag_editor,
+                                       args.flag_encrypted,
+                                       args.flag_yes));
+            }
+
+            // delete
+            if args.cmd_del {
+                profile.delete_note(&args.arg_id);
+            }
+
+            // transfer
+            if args.cmd_transfer {
+                // transfer a note
+                try!(profile.transfer_note(args));
+            }
+
+            // clear
+            if args.cmd_clear {
+                try!(profile.clear(args.flag_yes));
+            }
+
+            // decrypt profile
+            // FIXME: should test how this interacts with save_to_file when the profile has
+            //        changed during execution
+            if args.cmd_decrypt_profile {
+                profile.encrypted = false; // is it that easy? i think it is
+                println!("decrypting '{}'", args.flag_profile);
+            }
+
+            // encrypt profile
+            // FIXME: should test how this interacts with save_to_file when the profile has
+            //        changed during execution
+            if args.cmd_encrypt_profile {
+                // get the new key
+                if args.flag_new_key.is_empty() {
+                    args.flag_new_key = try!(get_password());
+                }
+
+                // set args.key and args.encrypted
+                args.flag_encrypted = true;
+                args.flag_key = args.flag_new_key.clone();
+
+                // set profile to encrypted
+                profile.encrypted = true;
+                println!("encrypting '{}'", args.flag_profile);
+            }
+
+            // new profile
+            if args.cmd_new_profile {
+                if args.cmd_new_profile && args.arg_name.is_empty() {
+                    args.arg_name.push("default".to_string())
+                }
+                println!("creating profile '{}'", args.arg_name[0]);
+            }
+
+            try!(profile.save_to_file(args, profile_fingerprint));
         }
+        false => {
+            // view
+            if !args.arg_id.is_empty() {
+                try!(profile.view_note(args.arg_id[0], args.flag_json, args.flag_condensed));
+                return Ok(());
+            }
 
-        // stats
-        if args.cmd_info {
-            try!(profile.stats(&args.flag_profile));
-        }
+            // search
+            if args.cmd_search {
+                try!(profile.search_notes(&args.arg_pattern,
+                                          args.flag_regex,
+                                          args.flag_limit,
+                                          args.flag_condensed,
+                                          args.flag_json,
+                                          args.flag_datesort,
+                                          args.flag_reverse,
+                                          args.flag_search_body,
+                                          args.flag_none,
+                                          args.flag_started,
+                                          args.flag_urgent));
+                return Ok(());
+            }
 
-        if args.cmd_import {
-            // reverse(?) transfer a note
-            let mut from_args = args.clone();
-            from_args.cmd_transfer = args.cmd_import;
-            from_args.cmd_import = false;
-            from_args.flag_profile = args.arg_name[0].clone();
-            from_args.arg_name[0] = args.flag_profile.clone();
+            // stats
+            if args.cmd_info {
+                try!(profile.stats(&args.flag_profile));
+                return Ok(());
+            }
 
-            let (mut from_profile, from_fingerprint) = try!(ThecaProfile::new(
+            if args.cmd_import {
+                // reverse(?) transfer a note
+                let mut from_args = args.clone();
+                from_args.cmd_transfer = args.cmd_import;
+                from_args.cmd_import = false;
+                from_args.flag_profile = args.arg_name[0].clone();
+                from_args.arg_name[0] = args.flag_profile.clone();
+
+                let (mut from_profile, from_fingerprint) = try!(ThecaProfile::new(
                     &from_args.flag_profile,
                     &from_args.flag_profile_folder,
                     &from_args.flag_key,
@@ -961,25 +966,29 @@ pub fn parse_cmds(profile: &mut ThecaProfile,
                     from_args.flag_yes
                 ));
 
-            try!(parse_cmds(&mut from_profile, &mut from_args, &from_fingerprint));
-        }
+                try!(parse_cmds(&mut from_profile, &mut from_args, &from_fingerprint));
+                return Ok(());
+            }
 
-        if args.cmd_list_profiles {
-            let profile_path = try!(find_profile_folder(&args.flag_profile_folder));
-            try!(profiles_in_folder(&profile_path));
-        }
+            if args.cmd_list_profiles {
+                let profile_path = try!(find_profile_folder(&args.flag_profile_folder));
+                try!(profiles_in_folder(&profile_path));
+                return Ok(());
+            }
 
-        // list
-        if args.arg_id.is_empty() {
-            try!(profile.list_notes(args.flag_limit,
-                                    args.flag_condensed,
-                                    args.flag_json,
-                                    args.flag_datesort,
-                                    args.flag_reverse,
-                                    args.flag_search_body,
-                                    args.flag_none,
-                                    args.flag_started,
-                                    args.flag_urgent));
+            // list
+            if args.arg_id.is_empty() {
+                try!(profile.list_notes(args.flag_limit,
+                                        args.flag_condensed,
+                                        args.flag_json,
+                                        args.flag_datesort,
+                                        args.flag_reverse,
+                                        args.flag_search_body,
+                                        args.flag_none,
+                                        args.flag_started,
+                                        args.flag_urgent));
+                return Ok(());
+            }
         }
     }
 

--- a/src/theca/lib.rs
+++ b/src/theca/lib.rs
@@ -832,132 +832,130 @@ pub fn parse_cmds(profile: &mut ThecaProfile,
                   args: &mut Args,
                   profile_fingerprint: &u64)
                   -> Result<(), ThecaError> {
-    match [args.cmd_add,
-           args.cmd_edit,
-           args.cmd_encrypt_profile,
-           args.cmd_del,
-           args.cmd_decrypt_profile,
-           args.cmd_transfer,
-           args.cmd_clear,
-           args.cmd_new_profile]
-              .iter()
-              .any(|c| c == &true) {
-        true => {
-            // add
-            if args.cmd_add {
-                try!(profile.add_note(&args.arg_title,
-                                      &args.flag_body,
-                                      args.flag_started,
-                                      args.flag_urgent,
-                                      args.cmd__,
-                                      args.flag_editor,
-                                      true));
-            }
-
-            // edit
-            if args.cmd_edit {
-                try!(profile.edit_note(args.arg_id[0],
-                                       &args.arg_title,
-                                       &args.flag_body,
-                                       args.flag_started,
-                                       args.flag_urgent,
-                                       args.flag_none,
-                                       args.cmd__,
-                                       args.flag_editor,
-                                       args.flag_encrypted,
-                                       args.flag_yes));
-            }
-
-            // delete
-            if args.cmd_del {
-                profile.delete_note(&args.arg_id);
-            }
-
-            // transfer
-            if args.cmd_transfer {
-                // transfer a note
-                try!(profile.transfer_note(args));
-            }
-
-            // clear
-            if args.cmd_clear {
-                try!(profile.clear(args.flag_yes));
-            }
-
-            // decrypt profile
-            // FIXME: should test how this interacts with save_to_file when the profile has
-            //        changed during execution
-            if args.cmd_decrypt_profile {
-                profile.encrypted = false; // is it that easy? i think it is
-                println!("decrypting '{}'", args.flag_profile);
-            }
-
-            // encrypt profile
-            // FIXME: should test how this interacts with save_to_file when the profile has
-            //        changed during execution
-            if args.cmd_encrypt_profile {
-                // get the new key
-                if args.flag_new_key.is_empty() {
-                    args.flag_new_key = try!(get_password());
-                }
-
-                // set args.key and args.encrypted
-                args.flag_encrypted = true;
-                args.flag_key = args.flag_new_key.clone();
-
-                // set profile to encrypted
-                profile.encrypted = true;
-                println!("encrypting '{}'", args.flag_profile);
-            }
-
-            // new profile
-            if args.cmd_new_profile {
-                if args.cmd_new_profile && args.arg_name.is_empty() {
-                    args.arg_name.push("default".to_string())
-                }
-                println!("creating profile '{}'", args.arg_name[0]);
-            }
-
-            try!(profile.save_to_file(args, profile_fingerprint));
+    if [args.cmd_add,
+        args.cmd_edit,
+        args.cmd_encrypt_profile,
+        args.cmd_del,
+        args.cmd_decrypt_profile,
+        args.cmd_transfer,
+        args.cmd_clear,
+        args.cmd_new_profile]
+           .iter()
+           .any(|c| c == &true) {
+        // add
+        if args.cmd_add {
+            try!(profile.add_note(&args.arg_title,
+                                  &args.flag_body,
+                                  args.flag_started,
+                                  args.flag_urgent,
+                                  args.cmd__,
+                                  args.flag_editor,
+                                  true));
         }
-        false => {
-            // view
-            if !args.arg_id.is_empty() {
-                try!(profile.view_note(args.arg_id[0], args.flag_json, args.flag_condensed));
-                return Ok(());
+
+        // edit
+        if args.cmd_edit {
+            try!(profile.edit_note(args.arg_id[0],
+                                   &args.arg_title,
+                                   &args.flag_body,
+                                   args.flag_started,
+                                   args.flag_urgent,
+                                   args.flag_none,
+                                   args.cmd__,
+                                   args.flag_editor,
+                                   args.flag_encrypted,
+                                   args.flag_yes));
+        }
+
+        // delete
+        if args.cmd_del {
+            profile.delete_note(&args.arg_id);
+        }
+
+        // transfer
+        if args.cmd_transfer {
+            // transfer a note
+            try!(profile.transfer_note(args));
+        }
+
+        // clear
+        if args.cmd_clear {
+            try!(profile.clear(args.flag_yes));
+        }
+
+        // decrypt profile
+        // FIXME: should test how this interacts with save_to_file when the profile has
+        //        changed during execution
+        if args.cmd_decrypt_profile {
+            profile.encrypted = false; // is it that easy? i think it is
+            println!("decrypting '{}'", args.flag_profile);
+        }
+
+        // encrypt profile
+        // FIXME: should test how this interacts with save_to_file when the profile has
+        //        changed during execution
+        if args.cmd_encrypt_profile {
+            // get the new key
+            if args.flag_new_key.is_empty() {
+                args.flag_new_key = try!(get_password());
             }
 
-            // search
-            if args.cmd_search {
-                try!(profile.search_notes(&args.arg_pattern,
-                                          args.flag_regex,
-                                          args.flag_limit,
-                                          args.flag_condensed,
-                                          args.flag_json,
-                                          args.flag_datesort,
-                                          args.flag_reverse,
-                                          args.flag_search_body,
-                                          args.flag_none,
-                                          args.flag_started,
-                                          args.flag_urgent));
-                return Ok(());
+            // set args.key and args.encrypted
+            args.flag_encrypted = true;
+            args.flag_key = args.flag_new_key.clone();
+
+            // set profile to encrypted
+            profile.encrypted = true;
+            println!("encrypting '{}'", args.flag_profile);
+        }
+
+        // new profile
+        if args.cmd_new_profile {
+            if args.cmd_new_profile && args.arg_name.is_empty() {
+                args.arg_name.push("default".to_string())
             }
+            println!("creating profile '{}'", args.arg_name[0]);
+        }
 
-            // stats
-            if args.cmd_info {
-                try!(profile.stats(&args.flag_profile));
-                return Ok(());
-            }
+        try!(profile.save_to_file(args, profile_fingerprint));
+    } else {
+        // view
+        if !args.arg_id.is_empty() {
+            try!(profile.view_note(args.arg_id[0], args.flag_json, args.flag_condensed));
+            return Ok(());
+        }
 
-            if args.cmd_import {
-                // reverse(?) transfer a note
-                let mut from_args = args.clone();
-                from_args.cmd_transfer = args.cmd_import;
-                from_args.cmd_import = false;
-                from_args.flag_profile = args.arg_name[0].clone();
-                from_args.arg_name[0] = args.flag_profile.clone();
+        // search
+        if args.cmd_search {
+            try!(profile.search_notes(&args.arg_pattern,
+                                      args.flag_regex,
+                                      args.flag_limit,
+                                      args.flag_condensed,
+                                      args.flag_json,
+                                      args.flag_datesort,
+                                      args.flag_reverse,
+                                      args.flag_search_body,
+                                      args.flag_none,
+                                      args.flag_started,
+                                      args.flag_urgent));
+            return Ok(());
+        }
 
-                let (mut from_profile, from_fingerprint) = try!(ThecaProfile::new(
+        // stats
+        if args.cmd_info {
+            try!(profile.stats(&args.flag_profile));
+            return Ok(());
+        }
+
+        if args.cmd_import {
+            // reverse(?) transfer a note
+            let mut from_args = args.clone();
+            from_args.cmd_transfer = args.cmd_import;
+            from_args.cmd_import = false;
+            from_args.flag_profile = args.arg_name[0].clone();
+            from_args.arg_name[0] = args.flag_profile.clone();
+
+            let (mut from_profile, from_fingerprint) = try!(ThecaProfile::new(
                     &from_args.flag_profile,
                     &from_args.flag_profile_folder,
                     &from_args.flag_key,
@@ -966,29 +964,28 @@ pub fn parse_cmds(profile: &mut ThecaProfile,
                     from_args.flag_yes
                 ));
 
-                try!(parse_cmds(&mut from_profile, &mut from_args, &from_fingerprint));
-                return Ok(());
-            }
+            try!(parse_cmds(&mut from_profile, &mut from_args, &from_fingerprint));
+            return Ok(());
+        }
 
-            if args.cmd_list_profiles {
-                let profile_path = try!(find_profile_folder(&args.flag_profile_folder));
-                try!(profiles_in_folder(&profile_path));
-                return Ok(());
-            }
+        if args.cmd_list_profiles {
+            let profile_path = try!(find_profile_folder(&args.flag_profile_folder));
+            try!(profiles_in_folder(&profile_path));
+            return Ok(());
+        }
 
-            // list
-            if args.arg_id.is_empty() {
-                try!(profile.list_notes(args.flag_limit,
-                                        args.flag_condensed,
-                                        args.flag_json,
-                                        args.flag_datesort,
-                                        args.flag_reverse,
-                                        args.flag_search_body,
-                                        args.flag_none,
-                                        args.flag_started,
-                                        args.flag_urgent));
-                return Ok(());
-            }
+        // list
+        if args.arg_id.is_empty() {
+            try!(profile.list_notes(args.flag_limit,
+                                    args.flag_condensed,
+                                    args.flag_json,
+                                    args.flag_datesort,
+                                    args.flag_reverse,
+                                    args.flag_search_body,
+                                    args.flag_none,
+                                    args.flag_started,
+                                    args.flag_urgent));
+            return Ok(());
         }
     }
 

--- a/src/theca/lib.rs
+++ b/src/theca/lib.rs
@@ -415,7 +415,7 @@ impl ThecaProfile {
 
     /// add a item to the profile
     pub fn add_note(&mut self,
-                    title: &String,
+                    title: &str,
                     body: &Vec<String>,
                     started: bool,
                     urgent: bool,
@@ -495,7 +495,7 @@ impl ThecaProfile {
     /// edit an item in the profile
     pub fn edit_note(&mut self,
                      id: usize,
-                     title: &String,
+                     title: &str,
                      body: &Vec<String>,
                      started: bool,
                      urgent: bool,
@@ -590,7 +590,7 @@ impl ThecaProfile {
     }
 
     /// print information about the profile
-    pub fn stats(&mut self, name: &String) -> Result<(), ThecaError> {
+    pub fn stats(&mut self, name: &str) -> Result<(), ThecaError> {
         let no_s = self.notes.iter().filter(|n| n.status == "").count();
         let started_s = self.notes
                             .iter()
@@ -743,7 +743,7 @@ impl ThecaProfile {
 
     /// print notes search for in the profile
     pub fn search_notes(&mut self,
-                        pattern: &String,
+                        pattern: &str,
                         regex: bool,
                         limit: usize,
                         condensed: bool,

--- a/src/theca/lib.rs
+++ b/src/theca/lib.rs
@@ -727,9 +727,10 @@ impl ThecaProfile {
                               started_status,
                               urgent_status));
         } else {
-            match json {
-                true => println!("[]"),
-                false => println!("this profile is empty"),
+            if json {
+                println!("[]");
+            } else {
+                println!("this profile is empty");
             }
         }
         Ok(())
@@ -749,31 +750,30 @@ impl ThecaProfile {
                         started_status: bool,
                         urgent_status: bool)
                         -> Result<(), ThecaError> {
-        let notes: Vec<ThecaItem> = match regex {
-            true => {
-                let re = match Regex::new(&pattern[..]) {
-                    Ok(r) => r,
-                    Err(e) => specific_fail!(format!("regex error: {}.", e)),
-                };
-                self.notes
-                    .iter()
-                    .filter(|n| match search_body {
-                        true => re.is_match(&*n.body),
-                        false => re.is_match(&*n.title),
-                    })
-                    .map(|n| n.clone())
-                    .collect()
-            }
-            false => {
-                self.notes
-                    .iter()
-                    .filter(|n| match search_body {
-                        true => n.body.contains(&pattern[..]),
-                        false => n.title.contains(&pattern[..]),
-                    })
-                    .map(|n| n.clone())
-                    .collect()
-            }
+        let notes: Vec<ThecaItem> = if regex {
+            let re = match Regex::new(&pattern[..]) {
+                Ok(r) => r,
+                Err(e) => specific_fail!(format!("regex error: {}.", e)),
+            };
+            self.notes
+                .iter()
+                .filter(|n| if search_body {
+                    re.is_match(&*n.body)
+                } else {
+                    re.is_match(&*n.title)
+                })
+                .map(|n| n.clone())
+                .collect()
+        } else {
+            self.notes
+                .iter()
+                .filter(|n| if search_body {
+                    n.body.contains(&pattern[..])
+                } else {
+                    n.title.contains(&pattern[..])
+                })
+                .map(|n| n.clone())
+                .collect()
         };
         if notes.len() > 0 {
             try!(sorted_print(&mut notes.clone(),

--- a/src/theca/lib.rs
+++ b/src/theca/lib.rs
@@ -9,9 +9,6 @@
 // lib.rs
 //   main theca struct defintions and command parsing functions.
 
-#![crate_name="theca"]
-#![crate_type="lib"]
-
 //! Definitions of ThecaItem and ThecaProfile and their implementations
 
 extern crate core;
@@ -29,7 +26,6 @@ extern crate tempdir;
 use std::env::var;
 use std::io::{self, stdin, Read, Write};
 use std::iter::repeat;
-use std::path::Path;
 use std::fs::{File, create_dir};
 
 // random things
@@ -270,15 +266,13 @@ impl ThecaProfile {
     /// save the profile back to file (either plaintext or encrypted)
     pub fn save_to_file(&mut self, args: &Args, fingerprint: &u64) -> Result<(), ThecaError> {
         // set profile folder
-        let mut profile_pathbuf = try!(find_profile_folder(&args.flag_profile_folder));
+        let mut profile_path = try!(find_profile_folder(&args.flag_profile_folder));
 
         // set file name
         match args.cmd_new_profile {
-            true => profile_pathbuf.push(&(args.arg_name[0].to_string() + ".json")),
-            false => profile_pathbuf.push(&(args.flag_profile.to_string() + ".json")),
+            true => profile_path.push(&(args.arg_name[0].to_string() + ".json")),
+            false => profile_path.push(&(args.flag_profile.to_string() + ".json")),
         };
-
-        let profile_path: &Path = &profile_pathbuf;
 
         if args.cmd_new_profile && profile_path.exists() && !args.flag_yes {
             println!("profile {} already exists would you like to overwrite it?",
@@ -982,9 +976,8 @@ pub fn parse_cmds(profile: &mut ThecaProfile,
             }
 
             if args.cmd_list_profiles {
-                let profile_pathbuf = try!(find_profile_folder(&args.flag_profile_folder));
-                let profile_folder: &Path = &profile_pathbuf;
-                try!(profiles_in_folder(profile_folder));
+                let profile_path = try!(find_profile_folder(&args.flag_profile_folder));
+                try!(profiles_in_folder(&profile_path));
                 return Ok(());
             }
 

--- a/src/theca/lib.rs
+++ b/src/theca/lib.rs
@@ -837,132 +837,127 @@ pub fn parse_cmds(profile: &mut ThecaProfile,
                   args: &mut Args,
                   profile_fingerprint: &u64)
                   -> Result<(), ThecaError> {
-    match [args.cmd_add,
-           args.cmd_edit,
-           args.cmd_encrypt_profile,
-           args.cmd_del,
-           args.cmd_decrypt_profile,
-           args.cmd_transfer,
-           args.cmd_clear,
-           args.cmd_new_profile]
-              .iter()
-              .any(|c| c == &true) {
-        true => {
-            // add
-            if args.cmd_add {
-                try!(profile.add_note(&args.arg_title,
-                                      &args.flag_body,
-                                      args.flag_started,
-                                      args.flag_urgent,
-                                      args.cmd__,
-                                      args.flag_editor,
-                                      true));
-            }
-
-            // edit
-            if args.cmd_edit {
-                try!(profile.edit_note(args.arg_id[0],
-                                       &args.arg_title,
-                                       &args.flag_body,
-                                       args.flag_started,
-                                       args.flag_urgent,
-                                       args.flag_none,
-                                       args.cmd__,
-                                       args.flag_editor,
-                                       args.flag_encrypted,
-                                       args.flag_yes));
-            }
-
-            // delete
-            if args.cmd_del {
-                profile.delete_note(&args.arg_id);
-            }
-
-            // transfer
-            if args.cmd_transfer {
-                // transfer a note
-                try!(profile.transfer_note(args));
-            }
-
-            // clear
-            if args.cmd_clear {
-                try!(profile.clear(args.flag_yes));
-            }
-
-            // decrypt profile
-            // FIXME: should test how this interacts with save_to_file when the profile has
-            //        changed during execution
-            if args.cmd_decrypt_profile {
-                profile.encrypted = false; // is it that easy? i think it is
-                println!("decrypting '{}'", args.flag_profile);
-            }
-
-            // encrypt profile
-            // FIXME: should test how this interacts with save_to_file when the profile has
-            //        changed during execution
-            if args.cmd_encrypt_profile {
-                // get the new key
-                if args.flag_new_key.is_empty() {
-                    args.flag_new_key = try!(get_password());
-                }
-
-                // set args.key and args.encrypted
-                args.flag_encrypted = true;
-                args.flag_key = args.flag_new_key.clone();
-
-                // set profile to encrypted
-                profile.encrypted = true;
-                println!("encrypting '{}'", args.flag_profile);
-            }
-
-            // new profile
-            if args.cmd_new_profile {
-                if args.cmd_new_profile && args.arg_name.is_empty() {
-                    args.arg_name.push("default".to_string())
-                }
-                println!("creating profile '{}'", args.arg_name[0]);
-            }
-
-            try!(profile.save_to_file(args, profile_fingerprint));
+    if [args.cmd_add,
+        args.cmd_edit,
+        args.cmd_encrypt_profile,
+        args.cmd_del,
+        args.cmd_decrypt_profile,
+        args.cmd_transfer,
+        args.cmd_clear,
+        args.cmd_new_profile]
+           .iter()
+           .any(|c| *c) {
+        // add
+        if args.cmd_add {
+            try!(profile.add_note(&args.arg_title,
+                                  &args.flag_body,
+                                  args.flag_started,
+                                  args.flag_urgent,
+                                  args.cmd__,
+                                  args.flag_editor,
+                                  true));
         }
-        false => {
-            // view
-            if !args.arg_id.is_empty() {
-                try!(profile.view_note(args.arg_id[0], args.flag_json, args.flag_condensed));
-                return Ok(());
+
+        // edit
+        if args.cmd_edit {
+            try!(profile.edit_note(args.arg_id[0],
+                                   &args.arg_title,
+                                   &args.flag_body,
+                                   args.flag_started,
+                                   args.flag_urgent,
+                                   args.flag_none,
+                                   args.cmd__,
+                                   args.flag_editor,
+                                   args.flag_encrypted,
+                                   args.flag_yes));
+        }
+
+        // delete
+        if args.cmd_del {
+            profile.delete_note(&args.arg_id);
+        }
+
+        // transfer
+        if args.cmd_transfer {
+            // transfer a note
+            try!(profile.transfer_note(args));
+        }
+
+        // clear
+        if args.cmd_clear {
+            try!(profile.clear(args.flag_yes));
+        }
+
+        // decrypt profile
+        // FIXME: should test how this interacts with save_to_file when the profile has
+        //        changed during execution
+        if args.cmd_decrypt_profile {
+            profile.encrypted = false; // is it that easy? i think it is
+            println!("decrypting '{}'", args.flag_profile);
+        }
+
+        // encrypt profile
+        // FIXME: should test how this interacts with save_to_file when the profile has
+        //        changed during execution
+        if args.cmd_encrypt_profile {
+            // get the new key
+            if args.flag_new_key.is_empty() {
+                args.flag_new_key = try!(get_password());
             }
 
-            // search
-            if args.cmd_search {
-                try!(profile.search_notes(&args.arg_pattern,
-                                          args.flag_regex,
-                                          args.flag_limit,
-                                          args.flag_condensed,
-                                          args.flag_json,
-                                          args.flag_datesort,
-                                          args.flag_reverse,
-                                          args.flag_search_body,
-                                          args.flag_none,
-                                          args.flag_started,
-                                          args.flag_urgent));
-                return Ok(());
+            // set args.key and args.encrypted
+            args.flag_encrypted = true;
+            args.flag_key = args.flag_new_key.clone();
+
+            // set profile to encrypted
+            profile.encrypted = true;
+            println!("encrypting '{}'", args.flag_profile);
+        }
+
+        // new profile
+        if args.cmd_new_profile {
+            if args.cmd_new_profile && args.arg_name.is_empty() {
+                args.arg_name.push("default".to_string())
             }
+            println!("creating profile '{}'", args.arg_name[0]);
+        }
 
-            // stats
-            if args.cmd_info {
-                try!(profile.stats(&args.flag_profile));
-                return Ok(());
-            }
+        try!(profile.save_to_file(args, profile_fingerprint));
+    } else {
+        // view
+        if !args.arg_id.is_empty() {
+            try!(profile.view_note(args.arg_id[0], args.flag_json, args.flag_condensed));
+        }
 
-            if args.cmd_import {
-                // reverse(?) transfer a note
-                let mut from_args = args.clone();
-                from_args.cmd_transfer = args.cmd_import;
-                from_args.cmd_import = false;
-                from_args.flag_profile = args.arg_name[0].clone();
-                from_args.arg_name[0] = args.flag_profile.clone();
+        // search
+        if args.cmd_search {
+            try!(profile.search_notes(&args.arg_pattern,
+                                      args.flag_regex,
+                                      args.flag_limit,
+                                      args.flag_condensed,
+                                      args.flag_json,
+                                      args.flag_datesort,
+                                      args.flag_reverse,
+                                      args.flag_search_body,
+                                      args.flag_none,
+                                      args.flag_started,
+                                      args.flag_urgent));
+        }
 
-                let (mut from_profile, from_fingerprint) = try!(ThecaProfile::new(
+        // stats
+        if args.cmd_info {
+            try!(profile.stats(&args.flag_profile));
+        }
+
+        if args.cmd_import {
+            // reverse(?) transfer a note
+            let mut from_args = args.clone();
+            from_args.cmd_transfer = args.cmd_import;
+            from_args.cmd_import = false;
+            from_args.flag_profile = args.arg_name[0].clone();
+            from_args.arg_name[0] = args.flag_profile.clone();
+
+            let (mut from_profile, from_fingerprint) = try!(ThecaProfile::new(
                     &from_args.flag_profile,
                     &from_args.flag_profile_folder,
                     &from_args.flag_key,
@@ -971,29 +966,25 @@ pub fn parse_cmds(profile: &mut ThecaProfile,
                     from_args.flag_yes
                 ));
 
-                try!(parse_cmds(&mut from_profile, &mut from_args, &from_fingerprint));
-                return Ok(());
-            }
+            try!(parse_cmds(&mut from_profile, &mut from_args, &from_fingerprint));
+        }
 
-            if args.cmd_list_profiles {
-                let profile_path = try!(find_profile_folder(&args.flag_profile_folder));
-                try!(profiles_in_folder(&profile_path));
-                return Ok(());
-            }
+        if args.cmd_list_profiles {
+            let profile_path = try!(find_profile_folder(&args.flag_profile_folder));
+            try!(profiles_in_folder(&profile_path));
+        }
 
-            // list
-            if args.arg_id.is_empty() {
-                try!(profile.list_notes(args.flag_limit,
-                                        args.flag_condensed,
-                                        args.flag_json,
-                                        args.flag_datesort,
-                                        args.flag_reverse,
-                                        args.flag_search_body,
-                                        args.flag_none,
-                                        args.flag_started,
-                                        args.flag_urgent));
-                return Ok(());
-            }
+        // list
+        if args.arg_id.is_empty() {
+            try!(profile.list_notes(args.flag_limit,
+                                    args.flag_condensed,
+                                    args.flag_json,
+                                    args.flag_datesort,
+                                    args.flag_reverse,
+                                    args.flag_search_body,
+                                    args.flag_none,
+                                    args.flag_started,
+                                    args.flag_urgent));
         }
     }
 

--- a/src/theca/lineformat.rs
+++ b/src/theca/lineformat.rs
@@ -1,5 +1,5 @@
-//  _   _                    
-// | |_| |__   ___  ___ __ _ 
+//  _   _
+// | |_| |__   ___  ___ __ _
 // | __| '_ \ / _ \/ __/ _` |
 // | |_| | | |  __/ (_| (_| |
 //  \__|_| |_|\___|\___\__,_|
@@ -11,63 +11,66 @@
 //   tries to construct a line format that won't overflow the console
 //   width.
 
-use errors::{ThecaError};
-use ::{ThecaItem};
-use utils::{termsize};
+use errors::ThecaError;
+use ThecaItem;
+use utils::termsize;
 
-#[derive(Copy)]
+#[derive(Clone, Copy)]
 pub struct LineFormat {
     pub colsep: usize,
     pub id_width: usize,
     pub title_width: usize,
     pub status_width: usize,
-    pub touched_width: usize
+    pub touched_width: usize,
 }
 
 impl LineFormat {
-    pub fn new(
-        items: &Vec<ThecaItem>,
-        condensed: bool,
-        search: bool
-    ) -> Result<LineFormat, ThecaError> {
+    pub fn new(items: &Vec<ThecaItem>,
+               condensed: bool,
+               search: bool)
+               -> Result<LineFormat, ThecaError> {
         // get termsize :>
         let console_width = termsize();
 
         // set colsep
         let colsep = match condensed {
             true => 1,
-            false => 2
+            false => 2,
         };
 
         let mut line_format = LineFormat {
             colsep: colsep,
-            id_width:0,
-            title_width:0,
-            status_width:0,
-            touched_width:0
+            id_width: 0,
+            title_width: 0,
+            status_width: 0,
+            touched_width: 0,
         };
 
         // get length of longest id string
         line_format.id_width = match items.iter()
-                                          .max_by(|n| n.id.to_string().len()) {
+                                          .max_by_key(|n| n.id.to_string().len()) {
             Some(w) => w.id.to_string().len(),
-            None => 0
+            None => 0,
         };
         // if longest id is 1 char and we are using extended printing
         // then set id_width to 2 so "id" isn't truncated
-        if line_format.id_width < 2 && !condensed {line_format.id_width = 2;}
+        if line_format.id_width < 2 && !condensed {
+            line_format.id_width = 2;
+        }
 
         // get length of longest title string
         line_format.title_width = match items.iter()
-                                             .max_by(|n| match n.body.len() > 0 {
-            true => n.title.len()+4,
-            false => n.title.len()
-        }) {
-            Some(n) => match n.body.is_empty() || search {
-                true => n.title.len(),
-                false => n.title.len()+4
-            },
-            None => 0
+                                             .max_by_key(|n| match n.body.len() > 0 {
+                                                 true => n.title.len() + 4,
+                                                 false => n.title.len(),
+                                             }) {
+            Some(n) => {
+                match n.body.is_empty() || search {
+                    true => n.title.len(),
+                    false => n.title.len() + 4,
+                }
+            }
+            None => 0,
         };
         // if using extended and longest title is less than 5 chars
         // set title_width to 5 so "title" won't be truncated
@@ -82,36 +85,32 @@ impl LineFormat {
                 match condensed {
                     // expanded print, get longest status (7 or 6 / started or urgent)
                     false => {
-                        match items.iter().max_by(|n| n.status.len()) {
+                        match items.iter().max_by_key(|n| n.status.len()) {
                             Some(w) => w.status.len(),
-                            None => {
-                                0
-                            }
+                            None => 0,
                         }
-                    },
+                    }
                     // only display first char of status (e.g. S or U) for condensed print
-                    true => 1
+                    true => 1,
                 }
-            },
-            // no items have statuses so truncate column
-            false => {
-                0
             }
+            // no items have statuses so truncate column
+            false => 0,
         };
 
         // last_touched has fixed string length so no need for silly iter stuff
         line_format.touched_width = match condensed {
             true => 10, // condensed
-            false => 19 // expanded
+            false => 19, // expanded
         };
 
         // check to make sure our new line format isn't bigger than the console
         let line_width = line_format.line_width();
         if console_width > 0 && line_width > console_width &&
-           (line_format.title_width-(line_width-console_width)) > 0 {
+           (line_format.title_width - (line_width - console_width)) > 0 {
             // if it is trim text from the title width since it is always the biggest...
             // if there isn't any statuses, also give the title the colsep char space
-            line_format.title_width -= line_width-console_width;
+            line_format.title_width -= line_width - console_width;
         }
 
         Ok(line_format)
@@ -119,9 +118,9 @@ impl LineFormat {
 
     pub fn line_width(&self) -> usize {
         let columns = match self.status_width == 0 {
-            true => 2*self.colsep,
-            false => 3*self.colsep
+            true => 2 * self.colsep,
+            false => 3 * self.colsep,
         };
-        self.id_width+self.title_width+self.status_width+self.touched_width+columns
+        self.id_width + self.title_width + self.status_width + self.touched_width + columns
     }
 }

--- a/src/theca/lineformat.rs
+++ b/src/theca/lineformat.rs
@@ -82,7 +82,7 @@ impl LineFormat {
 
         // status length stuff
         line_format.status_width = if items.iter()
-                                              .any(|n| n.status.len() > 0) {
+                                           .any(|n| n.status.len() > 0) {
             if condensed {
                 // only display first char of status (e.g. S or U) for condensed print
                 1

--- a/src/theca/lineformat.rs
+++ b/src/theca/lineformat.rs
@@ -11,8 +11,8 @@
 //   tries to construct a line format that won't overflow the console
 //   width.
 
-use errors::ThecaError;
-use {ThecaItem, Status};
+use errors::Result;
+use {Item, Status};
 use utils::termsize;
 
 #[derive(Clone, Copy)]
@@ -25,10 +25,10 @@ pub struct LineFormat {
 }
 
 impl LineFormat {
-    pub fn new(items: &Vec<ThecaItem>,
+    pub fn new(items: &Vec<Item>,
                condensed: bool,
                search: bool)
-               -> Result<LineFormat, ThecaError> {
+               -> Result<LineFormat> {
         // get termsize :>
         let console_width = termsize();
 

--- a/src/theca/lineformat.rs
+++ b/src/theca/lineformat.rs
@@ -33,9 +33,10 @@ impl LineFormat {
         let console_width = termsize();
 
         // set colsep
-        let colsep = match condensed {
-            true => 1,
-            false => 2,
+        let colsep = if condensed {
+            1
+        } else {
+            2
         };
 
         let mut line_format = LineFormat {
@@ -65,9 +66,10 @@ impl LineFormat {
                                                  false => n.title.len(),
                                              }) {
             Some(n) => {
-                match n.body.is_empty() || search {
-                    true => n.title.len(),
-                    false => n.title.len() + 4,
+                if n.body.is_empty() || search {
+                    n.title.len()
+                } else {
+                    n.title.len() + 4
                 }
             }
             None => 0,
@@ -79,29 +81,28 @@ impl LineFormat {
         }
 
         // status length stuff
-        line_format.status_width = match items.iter()
+        line_format.status_width = if items.iter()
                                               .any(|n| n.status.len() > 0) {
-            true => {
-                match condensed {
-                    // expanded print, get longest status (7 or 6 / started or urgent)
-                    false => {
-                        match items.iter().max_by_key(|n| n.status.len()) {
-                            Some(w) => w.status.len(),
-                            None => 0,
-                        }
-                    }
-                    // only display first char of status (e.g. S or U) for condensed print
-                    true => 1,
+            if condensed {
+                // only display first char of status (e.g. S or U) for condensed print
+                1
+            } else {
+                // expanded print, get longest status (7 or 6 / started or urgent)
+                match items.iter().max_by_key(|n| n.status.len()) {
+                    Some(w) => w.status.len(),
+                    None => 0,
                 }
             }
+        } else {
             // no items have statuses so truncate column
-            false => 0,
+            0
         };
 
         // last_touched has fixed string length so no need for silly iter stuff
-        line_format.touched_width = match condensed {
-            true => 10, // condensed
-            false => 19, // expanded
+        line_format.touched_width = if condensed {
+            10 // condensed
+        } else {
+            19 // expanded
         };
 
         // check to make sure our new line format isn't bigger than the console
@@ -117,9 +118,10 @@ impl LineFormat {
     }
 
     pub fn line_width(&self) -> usize {
-        let columns = match self.status_width == 0 {
-            true => 2 * self.colsep,
-            false => 3 * self.colsep,
+        let columns = if self.status_width == 0 {
+            2 * self.colsep
+        } else {
+            3 * self.colsep
         };
         self.id_width + self.title_width + self.status_width + self.touched_width + columns
     }

--- a/src/theca/lineformat.rs
+++ b/src/theca/lineformat.rs
@@ -12,7 +12,7 @@
 //   width.
 
 use errors::ThecaError;
-use ThecaItem;
+use {ThecaItem, Status};
 use utils::termsize;
 
 #[derive(Clone, Copy)]
@@ -82,14 +82,14 @@ impl LineFormat {
 
         // status length stuff
         line_format.status_width = if items.iter()
-                                           .any(|n| n.status.len() > 0) {
+                                           .any(|n| n.status != Status::NoStatus) {
             if condensed {
                 // only display first char of status (e.g. S or U) for condensed print
                 1
             } else {
                 // expanded print, get longest status (7 or 6 / started or urgent)
-                match items.iter().max_by_key(|n| n.status.len()) {
-                    Some(w) => w.status.len(),
+                match items.iter().max_by_key(|n| format!("{}", n.status).len()) {
+                    Some(w) => format!("{}", w.status).len(),
                     None => 0,
                 }
             }

--- a/src/theca/utils.rs
+++ b/src/theca/utils.rs
@@ -1,5 +1,5 @@
-//  _   _                    
-// | |_| |__   ___  ___ __ _ 
+//  _   _
+// | |_| |__   ___  ___ __ _
 // | __| '_ \ / _ \/ __/ _` |
 // | |_| | | |  __/ (_| (_| |
 //  \__|_| |_|\___|\___\__,_|
@@ -10,64 +10,50 @@
 //   various utility functions for doings things we need to do.
 
 // std imports
-use std::fs::{PathExt, read_dir, File};
+use std::fs::{read_dir, File};
 use std::io::{Write, Read};
-use std::os::errno;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::env::{var, home_dir};
-use std::cmp::{Ordering};
-use std::iter::{repeat};
+use std::cmp::Ordering;
+use std::iter::repeat;
 
 // time imports
-use time::{get_time};
+use time::get_time;
 use time::{strftime, strptime, at, Tm};
 
 // term imports
-use term::{stdout};
-use term::attr::Attr::{Bold};
+use term::stdout;
+use term::Attr::Bold;
 
 // json imports
 use rustc_serialize::json::{as_pretty_json, decode};
 
 // tempdir imports
-use tempdir::{TempDir};
+use tempdir::TempDir;
 
-// old imports
-use std::old_io::stdio::{stdin};
-use std::old_io::{IoError};
+use std::io::stdin;
+use std::io::Error as IoError;
 
 // theca imports
-use ::{DATEFMT, DATEFMT_SHORT, ThecaItem, ThecaProfile};
+use {DATEFMT, DATEFMT_SHORT, ThecaItem, ThecaProfile};
 use errors::{ThecaError, GenericError};
-use lineformat::{LineFormat};
+use lineformat::LineFormat;
 
-pub use libc::{
-    STDIN_FILENO,
-    STDOUT_FILENO,
-    STDERR_FILENO
-};
+pub use libc::{STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO};
 
 // c calls for TIOCGWINSZ
 pub mod c {
     extern crate libc;
-    pub use self::libc::{
-        c_int,
-        c_uint,
-        c_ushort,
-        c_ulong,
-        c_uchar,
-        STDOUT_FILENO,
-        isatty
-    };
+    pub use self::libc::{c_int, c_uint, c_ushort, c_ulong, c_uchar, STDOUT_FILENO, isatty};
     use std::mem::zeroed;
-    #[derive(Copy)]
+    #[derive(Clone, Copy)]
     pub struct Winsize {
         pub ws_row: c_ushort,
-        pub ws_col: c_ushort
+        pub ws_col: c_ushort,
     }
     #[repr(C)]
-    #[derive(Copy)]
+    #[derive(Clone, Copy)]
     pub struct Termios {
         pub c_iflag: c_uint,
         pub c_oflag: c_uint,
@@ -80,29 +66,28 @@ pub mod c {
     }
     impl Termios {
         pub fn new() -> Termios {
-            unsafe {zeroed()}
+            unsafe { zeroed() }
         }
     }
     pub fn tcgetattr(fd: c_int, termios_p: &mut Termios) -> c_int {
-        extern {fn tcgetattr(fd: c_int, termios_p: *mut Termios) -> c_int;}
-        unsafe {tcgetattr(fd, termios_p as *mut _)}
+        extern "C" {
+            fn tcgetattr(fd: c_int, termios_p: *mut Termios) -> c_int;
+        }
+        unsafe { tcgetattr(fd, termios_p as *mut _) }
     }
-    pub fn tcsetattr(
-        fd: c_int,
-        optional_actions: c_int,
-        termios_p: &Termios
-    ) -> c_int {
-        extern {fn tcsetattr(fd: c_int, optional_actions: c_int,
-                              termios_p: *const Termios) -> c_int;}
-        unsafe {tcsetattr(fd, optional_actions, termios_p as *const _)}
+    pub fn tcsetattr(fd: c_int, optional_actions: c_int, termios_p: &Termios) -> c_int {
+        extern "C" {
+            fn tcsetattr(fd: c_int, optional_actions: c_int, termios_p: *const Termios) -> c_int;
+        }
+        unsafe { tcsetattr(fd, optional_actions, termios_p as *const _) }
     }
-    pub const ECHO:c_uint = 8;
+    pub const ECHO: c_uint = 8;
     pub const TCSANOW: c_int = 0;
     #[cfg(any(target_os = "linux", target_os = "android"))]
     static TIOCGWINSZ: c_ulong = 0x5413;
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     static TIOCGWINSZ: c_ulong = 0x40087468;
-    extern {
+    extern "C" {
         pub fn ioctl(fd: c_int, request: c_ulong, ...) -> c_int;
     }
     pub unsafe fn dimensions() -> Winsize {
@@ -111,7 +96,7 @@ pub mod c {
         window
     }
     pub fn istty(fd: c_int) -> bool {
-        let isit = unsafe {isatty(fd as i32)};
+        let isit = unsafe { isatty(fd as i32) };
         isit != 0
     }
 }
@@ -121,7 +106,7 @@ fn set_term_echo(echo: bool) -> Result<(), ThecaError> {
     try_errno!(c::tcgetattr(STDIN_FILENO, &mut t));
     match echo {
         true => t.c_lflag |= c::ECHO,  // on
-        false => t.c_lflag &= !c::ECHO  // off
+        false => t.c_lflag &= !c::ECHO,  // off
     };
     try_errno!(c::tcsetattr(STDIN_FILENO, c::TCSANOW, &mut t));
     Ok(())
@@ -129,11 +114,10 @@ fn set_term_echo(echo: bool) -> Result<(), ThecaError> {
 
 // unsafety wrapper
 pub fn termsize() -> usize {
-    let ws = unsafe {c::dimensions()};
+    let ws = unsafe { c::dimensions() };
     if ws.ws_col <= 0 || ws.ws_row <= 0 {
         0
-    }
-    else {
+    } else {
         ws.ws_col as usize
     }
 }
@@ -148,9 +132,11 @@ pub fn drop_to_editor(contents: &String) -> Result<String, ThecaError> {
     try!(tmpfile.write_all(contents.as_bytes()));
     let editor = match var("VISUAL") {
         Ok(v) => v,
-        Err(_) => match var("EDITOR") {
-            Ok(v) => v,
-            Err(_) => specific_fail_str!("neither $VISUAL nor $EDITOR is set.")
+        Err(_) => {
+            match var("EDITOR") {
+                Ok(v) => v,
+                Err(_) => specific_fail_str!("neither $VISUAL nor $EDITOR is set."),
+            }
         }
     };
     // lets start `editor` and edit the file at `tmppath`
@@ -170,7 +156,7 @@ pub fn drop_to_editor(contents: &String) -> Result<String, ThecaError> {
             try!(tmpfile.read_to_string(&mut content));
             Ok(content)
         }
-        false => specific_fail_str!("the editor broke... I think")
+        false => specific_fail_str!("the editor broke... I think"),
     }
 }
 
@@ -178,37 +164,43 @@ pub fn get_password() -> Result<String, ThecaError> {
     // should really turn off terminal echo...
     print!("Key: ");
     let tty = c::istty(STDIN_FILENO);
-    if tty {try!(set_term_echo(false));}
-    let mut stdin = stdin();
+    if tty {
+        try!(set_term_echo(false));
+    }
+    let stdin = stdin();
+    let mut key = String::new();
     // since this only reads one line of stdin it could still feasibly
     // be used with `-` to set note body?
-    let key = try!(stdin.read_line());
-    if tty {try!(set_term_echo(true));}
+    try!(stdin.read_line(&mut key));
+    if tty {
+        try!(set_term_echo(true));
+    }
     println!("");
     Ok(key.trim().to_string())
 }
 
 pub fn get_yn_input() -> Result<bool, ThecaError> {
-    let mut stdin = stdin();
-    let mut answer;
+    let stdin = stdin();
+    let answer;
     let yes = vec!["y", "Y", "yes", "YES", "Yes"];
     let no = vec!["n", "N", "no", "NO", "No"];
     loop {
         print!("[y/n]# ");
-        let mut input = try!(stdin.read_line());
+        let mut input = String::new();
+        try!(stdin.read_line(&mut input));
         input = input.trim().to_string();
         match yes.iter().any(|n| &n[..] == input) {
             true => {
                 answer = true;
                 break;
-            },
+            }
             false => {
                 match no.iter().any(|n| &n[..] == input) {
                     true => {
                         answer = false;
                         break;
-                    },
-                    false => ()
+                    }
+                    false => (),
                 }
             }
         };
@@ -217,25 +209,25 @@ pub fn get_yn_input() -> Result<bool, ThecaError> {
     Ok(answer)
 }
 
-pub fn pretty_line(
-    bold: &str,
-    plain: &String,
-    tty: bool
-) -> Result<(), ThecaError> {
+pub fn pretty_line(bold: &str, plain: &String, tty: bool) -> Result<(), ThecaError> {
     let mut t = match stdout() {
         Some(t) => t,
-        None => specific_fail_str!("could not retrieve standard output.")
+        None => specific_fail_str!("could not retrieve standard output."),
     };
-    if tty {try!(t.attr(Bold));}
+    if tty {
+        try!(t.attr(Bold));
+    }
     try!(write!(t, "{}", bold.to_string()));
-    if tty {try!(t.reset());}
+    if tty {
+        try!(t.reset());
+    }
     try!(write!(t, "{}", plain));
     Ok(())
 }
 
 pub fn format_field(value: &String, width: usize, truncate: bool) -> String {
     if value.len() > width && width > 3 && truncate {
-        format!("{: <1$.1$}...", value, width-3)
+        format!("{: <1$.1$}...", value, width - 3)
     } else {
         format!("{: <1$.1$}", value, width)
     }
@@ -244,56 +236,52 @@ pub fn format_field(value: &String, width: usize, truncate: bool) -> String {
 fn print_header(line_format: &LineFormat) -> Result<(), ThecaError> {
     let mut t = match stdout() {
         Some(t) => t,
-        None => specific_fail_str!("could not retrieve standard output.")
+        None => specific_fail_str!("could not retrieve standard output."),
     };
-    let column_seperator: String = repeat(' ').take(line_format.colsep)
-                                              .collect();
-    let header_seperator: String = repeat('-').take(line_format.line_width())
-                                              .collect();
+    let column_seperator: String = repeat(' ')
+                                       .take(line_format.colsep)
+                                       .collect();
+    let header_seperator: String = repeat('-')
+                                       .take(line_format.line_width())
+                                       .collect();
     let tty = c::istty(STDOUT_FILENO);
     let status = match line_format.status_width == 0 {
         true => "".to_string(),
-        false => format_field(
-            &"status".to_string(),
-            line_format.status_width,
-            false
-        )+&*column_seperator
+        false => {
+            format_field(&"status".to_string(), line_format.status_width, false) +
+            &*column_seperator
+        }
     };
-    if tty {try!(t.attr(Bold));}
-    try!(write!(
-                t, 
+    if tty {
+        try!(t.attr(Bold));
+    }
+    try!(write!(t,
                 "{1}{0}{2}{0}{3}{4}\n{5}\n",
                 column_seperator,
                 format_field(&"id".to_string(), line_format.id_width, false),
-                format_field(
-                    &"title".to_string(),
-                    line_format.title_width,
-                    false
-                ),
+                format_field(&"title".to_string(), line_format.title_width, false),
                 status,
-                format_field(
-                    &"last touched".to_string(),
-                    line_format.touched_width,
-                    false
-                ),
-                header_seperator
-            ));
-    if tty {try!(t.reset());}
+                format_field(&"last touched".to_string(),
+                             line_format.touched_width,
+                             false),
+                header_seperator));
+    if tty {
+        try!(t.reset());
+    }
     Ok(())
 }
 
-pub fn sorted_print(
-    notes: &mut Vec<ThecaItem>,
-    limit: usize,
-    condensed: bool,
-    json: bool,
-    datesort: bool,
-    reverse: bool,
-    search_body: bool,
-    no_status: bool,
-    started_status: bool,
-    urgent_status: bool
-) -> Result<(), ThecaError> {
+pub fn sorted_print(notes: &mut Vec<ThecaItem>,
+                    limit: usize,
+                    condensed: bool,
+                    json: bool,
+                    datesort: bool,
+                    reverse: bool,
+                    search_body: bool,
+                    no_status: bool,
+                    started_status: bool,
+                    urgent_status: bool)
+                    -> Result<(), ThecaError> {
     if no_status {
         notes.retain(|n| n.status == "");
     } else if started_status {
@@ -303,47 +291,48 @@ pub fn sorted_print(
     }
     let limit = match limit != 0 && notes.len() >= limit {
         true => limit,
-        false => notes.len()
+        false => notes.len(),
     };
     if datesort {
-        notes.sort_by(|a, b| match cmp_last_touched(
-            &*a.last_touched,
-            &*b.last_touched
-        ) {
+        notes.sort_by(|a, b| match cmp_last_touched(&*a.last_touched, &*b.last_touched) {
             Ok(o) => o,
-            Err(_) => a.last_touched.cmp(&b.last_touched)
+            Err(_) => a.last_touched.cmp(&b.last_touched),
         });
     }
 
     match json {
         false => {
-            if reverse {notes.reverse();}
-            let line_format = try!(LineFormat::new(&notes[0..limit].to_vec(), condensed, search_body));
+            if reverse {
+                notes.reverse();
+            }
+            let line_format = try!(LineFormat::new(&notes[0..limit].to_vec(),
+                                                   condensed,
+                                                   search_body));
             if !condensed && !json {
                 try!(print_header(&line_format));
             }
             for n in notes[0..limit].iter() {
                 try!(n.print(&line_format, search_body));
             }
-        },
+        }
         true => {
-            if reverse { notes.reverse(); }
+            if reverse {
+                notes.reverse();
+            }
             println!("{}", as_pretty_json(&notes[0..limit].to_vec()))
         }
     };
-    
+
     Ok(())
 }
 
-pub fn find_profile_folder(
-    profile_folder: &String
-) -> Result<PathBuf, ThecaError> {
+pub fn find_profile_folder(profile_folder: &String) -> Result<PathBuf, ThecaError> {
     if !profile_folder.is_empty() {
-        Ok(PathBuf::new(profile_folder))
+        Ok(PathBuf::from(profile_folder))
     } else {
         match home_dir() {
             Some(ref p) => Ok(p.join(".theca")),
-            None => specific_fail_str!("failed to find your home directory")
+            None => specific_fail_str!("failed to find your home directory"),
         }
     }
 }
@@ -366,33 +355,35 @@ pub fn cmp_last_touched(a: &str, b: &str) -> Result<Ordering, ThecaError> {
 pub fn validate_profile_from_path(profile_path: &PathBuf) -> (bool, bool) {
     // return (is_a_profile, encrypted(?))
     match profile_path.extension().unwrap() == "json" {
-        true => match File::open(profile_path) {
-            Ok(mut f) => {
-                let mut contents_buf: Vec<u8> = vec![];
-                match f.read_to_end(&mut contents_buf) {
-                    Ok(c) => c,
-                    // nopnopnopppppp
-                    Err(_) => return (false, false)
-                };
-                match String::from_utf8(contents_buf) {
-                    Ok(s) => {
-                        // well it's a .json and valid utf-8 at least
-                        match decode::<ThecaProfile>(&*s) {
-                            // yup
-                            Ok(_) => return (true, false),
-                            // noooooop
-                            Err(_) => return (false, false)
-                        };
-                    },
-                    // possibly encrypted
-                    Err(_) => return (true, true)
+        true => {
+            match File::open(profile_path) {
+                Ok(mut f) => {
+                    let mut contents_buf: Vec<u8> = vec![];
+                    match f.read_to_end(&mut contents_buf) {
+                        Ok(c) => c,
+                        // nopnopnopppppp
+                        Err(_) => return (false, false),
+                    };
+                    match String::from_utf8(contents_buf) {
+                        Ok(s) => {
+                            // well it's a .json and valid utf-8 at least
+                            match decode::<ThecaProfile>(&*s) {
+                                // yup
+                                Ok(_) => return (true, false),
+                                // noooooop
+                                Err(_) => return (false, false),
+                            };
+                        }
+                        // possibly encrypted
+                        Err(_) => return (true, true),
+                    }
                 }
-            },
-            // nooppp
-            Err(_) => return (false, false)
-        },
+                // nooppp
+                Err(_) => return (false, false),
+            }
+        }
         // noooppp
-        false => return (false, false)
+        false => return (false, false),
     };
 }
 

--- a/src/theca/utils.rs
+++ b/src/theca/utils.rs
@@ -17,6 +17,7 @@ use std::process::{Command, Stdio};
 use std::env::{var, home_dir};
 use std::cmp::Ordering;
 use std::iter::repeat;
+use std::time::UNIX_EPOCH;
 
 // time imports
 use time::get_time;
@@ -326,7 +327,15 @@ pub fn sorted_print(notes: &mut Vec<ThecaItem>,
     Ok(())
 }
 
-pub fn find_profile_folder(profile_folder: &String) -> Result<PathBuf, ThecaError> {
+pub fn profile_fingerprint<P: AsRef<Path>>(path: P) -> Result<u64, ThecaError> {
+    let path = path.as_ref();
+    let metadata = try!(path.metadata());
+    let modified = try!(metadata.modified());
+    let since_epoch = try!(modified.duration_since(UNIX_EPOCH));
+    Ok(since_epoch.as_secs())
+}
+
+pub fn find_profile_folder(profile_folder: &str) -> Result<PathBuf, ThecaError> {
     if !profile_folder.is_empty() {
         Ok(PathBuf::from(profile_folder))
     } else {

--- a/src/theca/utils.rs
+++ b/src/theca/utils.rs
@@ -157,7 +157,7 @@ pub fn drop_to_editor(contents: &str) -> Result<String, ThecaError> {
         try!(tmpfile.read_to_string(&mut content));
         Ok(content)
     } else {
-        specific_fail_str!("the editor broke... I think") 
+        specific_fail_str!("the editor broke... I think")
     }
 }
 
@@ -195,8 +195,8 @@ pub fn get_yn_input() -> Result<bool, ThecaError> {
             break;
         } else {
             if no.iter().any(|n| &n[..] == input) {
-                    answer = false;
-                    break;
+                answer = false;
+                break;
             }
         };
         println!("invalid input.");
@@ -241,10 +241,9 @@ fn print_header(line_format: &LineFormat) -> Result<(), ThecaError> {
                                        .collect();
     let tty = c::istty(STDOUT_FILENO);
     let status = if line_format.status_width == 0 {
-        true => "".to_string(),
+        "".to_string()
     } else {
-            format_field(&"status".to_string(), line_format.status_width, false) +
-            &*column_seperator
+        format_field(&"status".to_string(), line_format.status_width, false) + &*column_seperator
     };
     if tty {
         try!(t.attr(Bold));
@@ -304,9 +303,7 @@ pub fn sorted_print(notes: &mut Vec<ThecaItem>,
         if reverse {
             notes.reverse();
         }
-        let line_format = try!(LineFormat::new(&notes[0..limit].to_vec(),
-                                                condensed,
-                                                search_body));
+        let line_format = try!(LineFormat::new(&notes[0..limit].to_vec(), condensed, search_body));
         if !condensed && !json {
             try!(print_header(&line_format));
         }

--- a/src/theca/utils.rs
+++ b/src/theca/utils.rs
@@ -37,7 +37,7 @@ use std::io::stdin;
 use std::io::Error as IoError;
 
 // theca imports
-use {DATEFMT, DATEFMT_SHORT, ThecaItem, ThecaProfile};
+use {DATEFMT, DATEFMT_SHORT, ThecaItem, ThecaProfile, Status};
 use errors::{ThecaError, GenericError};
 use lineformat::LineFormat;
 
@@ -276,11 +276,11 @@ pub fn sorted_print(notes: &mut Vec<ThecaItem>,
                     urgent_status: bool)
                     -> Result<(), ThecaError> {
     if no_status {
-        notes.retain(|n| n.status == "");
+        notes.retain(|n| n.status == Status::NoStatus);
     } else if started_status {
-        notes.retain(|n| n.status == "Started");
+        notes.retain(|n| n.status == Status::Started);
     } else if urgent_status {
-        notes.retain(|n| n.status == "Urgent");
+        notes.retain(|n| n.status == Status::Urgent);
     }
     let limit = if limit != 0 && notes.len() >= limit {
         limit

--- a/src/theca/utils.rs
+++ b/src/theca/utils.rs
@@ -123,7 +123,7 @@ pub fn termsize() -> usize {
     }
 }
 
-pub fn drop_to_editor(contents: &String) -> Result<String, ThecaError> {
+pub fn drop_to_editor(contents: &str) -> Result<String, ThecaError> {
     // setup temporary directory
     let tmpdir = try!(TempDir::new("theca"));
     // setup temporary file to write/read
@@ -210,7 +210,7 @@ pub fn get_yn_input() -> Result<bool, ThecaError> {
     Ok(answer)
 }
 
-pub fn pretty_line(bold: &str, plain: &String, tty: bool) -> Result<(), ThecaError> {
+pub fn pretty_line(bold: &str, plain: &str, tty: bool) -> Result<(), ThecaError> {
     let mut t = match stdout() {
         Some(t) => t,
         None => specific_fail_str!("could not retrieve standard output."),
@@ -226,7 +226,7 @@ pub fn pretty_line(bold: &str, plain: &String, tty: bool) -> Result<(), ThecaErr
     Ok(())
 }
 
-pub fn format_field(value: &String, width: usize, truncate: bool) -> String {
+pub fn format_field(value: &str, width: usize, truncate: bool) -> String {
     if value.len() > width && width > 3 && truncate {
         format!("{: <1$.1$}...", value, width - 3)
     } else {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,6 +1,6 @@
 extern crate theca;
 
-use theca::ThecaProfile;
+use theca::{Status, ThecaProfile};
 
 #[test]
 fn test_add_note() {
@@ -12,7 +12,7 @@ fn test_add_note() {
     assert_eq!(p.notes.len(), 1);
     assert_eq!(p.notes[0].id, 1);
     assert_eq!(p.notes[0].title, "this is a title".to_string());
-    assert_eq!(p.notes[0].status, "".to_string());
+    assert_eq!(p.notes[0].status, Status::NoStatus);
     assert_eq!(p.notes[0].body, "".to_string());
 }
 
@@ -26,7 +26,7 @@ fn test_add_started_note() {
     assert_eq!(p.notes.len(), 1);
     assert_eq!(p.notes[0].id, 1);
     assert_eq!(p.notes[0].title, "this is a title".to_string());
-    assert_eq!(p.notes[0].status, "Started".to_string());
+    assert_eq!(p.notes[0].status, Status::Started);
     assert_eq!(p.notes[0].body, "".to_string());
 }
 
@@ -40,7 +40,7 @@ fn test_add_urgent_note() {
     assert_eq!(p.notes.len(), 1);
     assert_eq!(p.notes[0].id, 1);
     assert_eq!(p.notes[0].title, "this is a title".to_string());
-    assert_eq!(p.notes[0].status, "Urgent".to_string());
+    assert_eq!(p.notes[0].status, Status::Urgent);
     assert_eq!(p.notes[0].body, "".to_string());
 }
 
@@ -54,7 +54,7 @@ fn test_add_basic_body_note() {
     assert_eq!(p.notes.len(), 1);
     assert_eq!(p.notes[0].id, 1);
     assert_eq!(p.notes[0].title, "this is a title".to_string());
-    assert_eq!(p.notes[0].status, "".to_string());
+    assert_eq!(p.notes[0].status, Status::NoStatus);
     assert_eq!(p.notes[0].body, "and what?".to_string());
 }
 
@@ -68,7 +68,7 @@ fn test_add_full_basic_body_note() {
     assert_eq!(p.notes.len(), 1);
     assert_eq!(p.notes[0].id, 1);
     assert_eq!(p.notes[0].title, "this is a title".to_string());
-    assert_eq!(p.notes[0].status, "Urgent".to_string());
+    assert_eq!(p.notes[0].status, Status::Urgent);
     assert_eq!(p.notes[0].body, "and what?".to_string());
 }
 
@@ -83,7 +83,7 @@ fn test_edit_note_title() {
     assert!(p.edit_note(1, &"this is a new title".to_string(), &vec![], false, false, false, false, false, false, false).is_ok());
     assert_eq!(p.notes[0].id, 1);
     assert_eq!(p.notes[0].title, "this is a new title".to_string());
-    assert_eq!(p.notes[0].status, "".to_string());
+    assert_eq!(p.notes[0].status, Status::NoStatus);
     assert_eq!(p.notes[0].body, "".to_string());
 }
 
@@ -98,17 +98,17 @@ fn test_edit_note_status() {
     assert!(p.edit_note(1, &"".to_string(), &vec![], true, false, false, false, false, false, false).is_ok());
     assert_eq!(p.notes[0].id, 1);
     assert_eq!(p.notes[0].title, "this is a title".to_string());
-    assert_eq!(p.notes[0].status, "Started".to_string());
+    assert_eq!(p.notes[0].status, Status::Started);
     assert_eq!(p.notes[0].body, "".to_string());
     assert!(p.edit_note(1, &"".to_string(), &vec![], false, true, false, false, false, false, false).is_ok());
     assert_eq!(p.notes[0].id, 1);
     assert_eq!(p.notes[0].title, "this is a title".to_string());
-    assert_eq!(p.notes[0].status, "Urgent".to_string());
+    assert_eq!(p.notes[0].status, Status::Urgent);
     assert_eq!(p.notes[0].body, "".to_string());
     assert!(p.edit_note(1, &"".to_string(), &vec![], false, false, true, false, false, false, false).is_ok());
     assert_eq!(p.notes[0].id, 1);
     assert_eq!(p.notes[0].title, "this is a title".to_string());
-    assert_eq!(p.notes[0].status, "".to_string());
+    assert_eq!(p.notes[0].status, Status::NoStatus);
     assert_eq!(p.notes[0].body, "".to_string());
 }
 
@@ -123,7 +123,7 @@ fn test_edit_note_body_basic() {
     assert!(p.edit_note(1, &"".to_string(), &vec!["woo body".to_string()], false, false, false, false, false, false, false).is_ok());
     assert_eq!(p.notes[0].id, 1);
     assert_eq!(p.notes[0].title, "this is a title".to_string());
-    assert_eq!(p.notes[0].status, "".to_string());
+    assert_eq!(p.notes[0].status, Status::NoStatus);
     assert_eq!(p.notes[0].body, "woo body".to_string());
 }
 
@@ -138,7 +138,7 @@ fn test_edit_full_note() {
     assert!(p.edit_note(1, &"this is a new title".to_string(), &vec!["woo body".to_string()], true, false, false, false, false, false, false).is_ok());
     assert_eq!(p.notes[0].id, 1);
     assert_eq!(p.notes[0].title, "this is a new title".to_string());
-    assert_eq!(p.notes[0].status, "Started".to_string());
+    assert_eq!(p.notes[0].status, Status::Started);
     assert_eq!(p.notes[0].body, "woo body".to_string());
 }
 
@@ -169,7 +169,7 @@ fn test_delete_some_notes() {
     assert_eq!(p.notes.len(), 1);
     assert_eq!(p.notes[0].id, 2);
     assert_eq!(p.notes[0].title, "this is a title".to_string());
-    assert_eq!(p.notes[0].status, "".to_string());
+    assert_eq!(p.notes[0].status, Status::NoStatus);
     assert_eq!(p.notes[0].body, "".to_string());
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,10 +1,10 @@
 extern crate theca;
 
-use theca::{Status, ThecaProfile};
+use theca::{Status, Profile};
 
 #[test]
 fn test_add_note() {
-    let mut p = ThecaProfile {
+    let mut p = Profile {
         encrypted: false,
         notes: vec![]
     };
@@ -18,7 +18,7 @@ fn test_add_note() {
 
 #[test]
 fn test_add_started_note() {
-    let mut p = ThecaProfile {
+    let mut p = Profile {
         encrypted: false,
         notes: vec![]
     };
@@ -32,7 +32,7 @@ fn test_add_started_note() {
 
 #[test]
 fn test_add_urgent_note() {
-    let mut p = ThecaProfile {
+    let mut p = Profile {
         encrypted: false,
         notes: vec![]
     };
@@ -46,7 +46,7 @@ fn test_add_urgent_note() {
 
 #[test]
 fn test_add_basic_body_note() {
-    let mut p = ThecaProfile {
+    let mut p = Profile {
         encrypted: false,
         notes: vec![]
     };
@@ -60,7 +60,7 @@ fn test_add_basic_body_note() {
 
 #[test]
 fn test_add_full_basic_body_note() {
-    let mut p = ThecaProfile {
+    let mut p = Profile {
         encrypted: false,
         notes: vec![]
     };
@@ -74,7 +74,7 @@ fn test_add_full_basic_body_note() {
 
 #[test]
 fn test_edit_note_title() {
-    let mut p = ThecaProfile {
+    let mut p = Profile {
         encrypted: false,
         notes: vec![]
     };
@@ -89,7 +89,7 @@ fn test_edit_note_title() {
 
 #[test]
 fn test_edit_note_status() {
-    let mut p = ThecaProfile {
+    let mut p = Profile {
         encrypted: false,
         notes: vec![]
     };
@@ -114,7 +114,7 @@ fn test_edit_note_status() {
 
 #[test]
 fn test_edit_note_body_basic() {
-    let mut p = ThecaProfile {
+    let mut p = Profile {
         encrypted: false,
         notes: vec![]
     };
@@ -129,7 +129,7 @@ fn test_edit_note_body_basic() {
 
 #[test]
 fn test_edit_full_note() {
-    let mut p = ThecaProfile {
+    let mut p = Profile {
         encrypted: false,
         notes: vec![]
     };
@@ -144,7 +144,7 @@ fn test_edit_full_note() {
 
 #[test]
 fn test_delete_single_note() {
-    let mut p = ThecaProfile {
+    let mut p = Profile {
         encrypted: false,
         notes: vec![]
     };
@@ -155,7 +155,7 @@ fn test_delete_single_note() {
 
 #[test]
 fn test_delete_some_notes() {
-    let mut p = ThecaProfile {
+    let mut p = Profile {
         encrypted: false,
         notes: vec![]
     };
@@ -175,7 +175,7 @@ fn test_delete_some_notes() {
 
 #[test]
 fn test_clear_notes() {
-    let mut p = ThecaProfile {
+    let mut p = Profile {
         encrypted: false,
         notes: vec![]
     };

--- a/tests/lineformat.rs
+++ b/tests/lineformat.rs
@@ -1,10 +1,10 @@
 extern crate theca;
 
-use theca::{Status, ThecaItem};
+use theca::{Status, Item};
 use theca::lineformat::{LineFormat};
 
 struct LineTest {
-    input_notes: Vec<ThecaItem>,
+    input_notes: Vec<Item>,
     condensed: bool,
     search: bool,
     expected_format: LineFormat
@@ -28,14 +28,14 @@ fn test_new_line_format_basic() {
     let basic_tests = vec![
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "".to_string(),
@@ -55,14 +55,14 @@ fn test_new_line_format_basic() {
         },
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "".to_string(),
@@ -90,14 +90,14 @@ fn test_new_line_format_statuses() {
     let status_tests = vec![
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::Started,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "".to_string(),
@@ -117,14 +117,14 @@ fn test_new_line_format_statuses() {
         },
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "".to_string(),
@@ -144,14 +144,14 @@ fn test_new_line_format_statuses() {
         },
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "".to_string(),
@@ -179,14 +179,14 @@ fn test_new_line_format_body() {
     let body_tests = vec![
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "this is a body".to_string(),
@@ -206,14 +206,14 @@ fn test_new_line_format_body() {
         },
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "this is a body".to_string(),
@@ -233,14 +233,14 @@ fn test_new_line_format_body() {
         },
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "this is a body".to_string(),
@@ -260,14 +260,14 @@ fn test_new_line_format_body() {
         },
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "this is a body".to_string(),
@@ -295,14 +295,14 @@ fn test_new_line_format_full() {
     let body_tests = vec![
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::Started,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "this is a body".to_string(),
@@ -322,14 +322,14 @@ fn test_new_line_format_full() {
         },
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::Started,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "this is a body".to_string(),
@@ -349,14 +349,14 @@ fn test_new_line_format_full() {
         },
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::Urgent,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "this is a body".to_string(),
@@ -376,14 +376,14 @@ fn test_new_line_format_full() {
         },
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "this is a body".to_string(),

--- a/tests/lineformat.rs
+++ b/tests/lineformat.rs
@@ -1,6 +1,6 @@
 extern crate theca;
 
-use theca::{ThecaItem};
+use theca::{Status, ThecaItem};
 use theca::lineformat::{LineFormat};
 
 struct LineTest {
@@ -32,14 +32,14 @@ fn test_new_line_format_basic() {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
-                    status: "".to_string(),
+                    status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
                 ThecaItem {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "".to_string(),
-                    status: "".to_string(),
+                    status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 }
             ],
@@ -59,14 +59,14 @@ fn test_new_line_format_basic() {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
-                    status: "".to_string(),
+                    status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
                 ThecaItem {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "".to_string(),
-                    status: "".to_string(),
+                    status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 }
             ],
@@ -94,14 +94,14 @@ fn test_new_line_format_statuses() {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
-                    status: "Started".to_string(),
+                    status: Status::Started,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
                 ThecaItem {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "".to_string(),
-                    status: "".to_string(),
+                    status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 }
             ],
@@ -121,14 +121,14 @@ fn test_new_line_format_statuses() {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
-                    status: "".to_string(),
+                    status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
                 ThecaItem {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "".to_string(),
-                    status: "Urgent".to_string(),
+                    status: Status::Urgent,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 }
             ],
@@ -148,14 +148,14 @@ fn test_new_line_format_statuses() {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
-                    status: "".to_string(),
+                    status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
                 ThecaItem {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "".to_string(),
-                    status: "Urgent".to_string(),
+                    status: Status::Urgent,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 }
             ],
@@ -183,14 +183,14 @@ fn test_new_line_format_body() {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
-                    status: "".to_string(),
+                    status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
                 ThecaItem {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "this is a body".to_string(),
-                    status: "".to_string(),
+                    status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 }
             ],
@@ -210,14 +210,14 @@ fn test_new_line_format_body() {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
-                    status: "".to_string(),
+                    status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
                 ThecaItem {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "this is a body".to_string(),
-                    status: "".to_string(),
+                    status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 }
             ],
@@ -237,14 +237,14 @@ fn test_new_line_format_body() {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
-                    status: "".to_string(),
+                    status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
                 ThecaItem {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "this is a body".to_string(),
-                    status: "".to_string(),
+                    status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 }
             ],
@@ -264,14 +264,14 @@ fn test_new_line_format_body() {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
-                    status: "".to_string(),
+                    status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
                 ThecaItem {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "this is a body".to_string(),
-                    status: "".to_string(),
+                    status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 }
             ],
@@ -299,14 +299,14 @@ fn test_new_line_format_full() {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
-                    status: "Started".to_string(),
+                    status: Status::Started,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
                 ThecaItem {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "this is a body".to_string(),
-                    status: "".to_string(),
+                    status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 }
             ],
@@ -326,14 +326,14 @@ fn test_new_line_format_full() {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
-                    status: "Started".to_string(),
+                    status: Status::Started,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
                 ThecaItem {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "this is a body".to_string(),
-                    status: "".to_string(),
+                    status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 }
             ],
@@ -353,14 +353,14 @@ fn test_new_line_format_full() {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
-                    status: "Urgent".to_string(),
+                    status: Status::Urgent,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
                 ThecaItem {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "this is a body".to_string(),
-                    status: "".to_string(),
+                    status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 }
             ],
@@ -380,14 +380,14 @@ fn test_new_line_format_full() {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
-                    status: "".to_string(),
+                    status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
                 ThecaItem {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "this is a body".to_string(),
-                    status: "Urgent".to_string(),
+                    status: Status::Urgent,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 }
             ],

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -62,7 +62,7 @@ case "$1" in
             if [[ "$@" =~ "--release" ]]; then
                 bin_loc="target/release/theca"
             else
-                bin_loc="target/theca"
+                bin_loc="target/debug/theca"
             fi
             p "built $bin_loc"
             cp "$bin_loc" bin/theca
@@ -134,7 +134,7 @@ case "$1" in
             cargo_cmd="cargo build --release"
         else
             build_profile="dev"
-            python_cmd="$python_cmd target/theca"
+            python_cmd="$python_cmd target/debug/theca"
             cargo_cmd="cargo build"
         fi
 


### PR DESCRIPTION
This is a pretty much mechanical translation of the `theca` code to a recent version of `rustc`. The version I compiled it with was `rustc 1.10.0 (cfcb716cf 2016-07-03)`, which as of this writing is the most recent stable version of rust. It also compiles with the latest beta and nightly.

As far as I can tell, no logic was changed. All the tests pass, and both `lib` and `bin` targets compile without warnings.

Closes #6 
